### PR TITLE
Feat:add support for section drag and drop

### DIFF
--- a/src/core/translations/translations-contract.ts
+++ b/src/core/translations/translations-contract.ts
@@ -35,6 +35,7 @@ export interface ITranslations {
     redo: string;
     image: string;
     barcode: string;
+    section: string;
 
     // Elements tree section labels
     header: string;
@@ -73,6 +74,7 @@ export const defaultTranslations: ITranslations = {
     redo: "Redo",
     image: "Image",
     barcode: "Barcode",
+    section: "Section",
     header: "Header",
     content: "Content",
     footer: "Footer",

--- a/src/designer/components/dataSourceTreeList.ts
+++ b/src/designer/components/dataSourceTreeList.ts
@@ -44,9 +44,16 @@ const dataSourceItemRenderer = (
   item: TreeItem<DataSourceTreeItemData>,
   itemData: TreeItemData<DataSourceTreeItemData>,
 ) => {
-  if (item.hasChild) return;
-
   item.element.draggable = true;
+
+  if (item.hasChild) {
+    item.element.addEventListener("dragstart", (e) => {
+      e.dataTransfer?.setData("label", itemData.label);
+      e.dataTransfer?.setData("type", "section");
+      e.dataTransfer?.setData("field", itemData.data.field);
+    });
+    return;
+  }
 
   item.element.addEventListener("dragstart", (e) => {
     e.dataTransfer?.setData("label", itemData.label);

--- a/src/designer/reportSection/reportSection.ts
+++ b/src/designer/reportSection/reportSection.ts
@@ -476,6 +476,8 @@ export default class ReportSection {
       });
 
       this.selectItem([item]);
+    } else if (type === "section") {
+      this.createSection({ binding: field });
     }
   }
 

--- a/src/designer/reportSection/reportSectionProperties.ts
+++ b/src/designer/reportSection/reportSectionProperties.ts
@@ -42,6 +42,7 @@ export default class ReportSectionProperties extends StyleProperties {
   getPropertyDefinitions(): Property[] {
     return [
       { field: "height", label: this.translations?.height ?? "Height", type: "number" },
+      { field: "binding", label: this.translations?.binding ?? "Binding", type: "text" },
       ...super.getPropertyDefinitions(),
     ];
   }

--- a/src/designer/reportSection/reportSectionProperties.ts
+++ b/src/designer/reportSection/reportSectionProperties.ts
@@ -42,7 +42,7 @@ export default class ReportSectionProperties extends StyleProperties {
   getPropertyDefinitions(): Property[] {
     return [
       { field: "height", label: this.translations?.height ?? "Height", type: "number" },
-      { field: "binding", label: this.translations?.binding ?? "Binding", type: "text" },
+      { field: "binding", label: this.translations?.binding ?? "Binding", type: "string" },
       ...super.getPropertyDefinitions(),
     ];
   }

--- a/src/designer/toolbar/toolbarButton.ts
+++ b/src/designer/toolbar/toolbarButton.ts
@@ -5,7 +5,7 @@ export interface ToolbarButtonOptions {
   text: string;
   title: string;
   draggable?: boolean;
-  type: "button" | "text" | "image" | "barcode";
+  type: "button" | "text" | "image" | "barcode" | "section";
 }
 
 export default class ToolbarButton {

--- a/src/designer/toolbar/toolbarLeftMenu.ts
+++ b/src/designer/toolbar/toolbarLeftMenu.ts
@@ -28,5 +28,12 @@ export default class ToolbarLeftMenu extends Toolbar {
       draggable: true,
       type: "barcode",
     });
+
+    this.addButton({
+      text: "☰",
+      title: translations.section,
+      draggable: true,
+      type: "section",
+    });
   }
 }


### PR DESCRIPTION
## Add section toolbar button and improve data source drag-drop

Previously, report sections could only be bound to data source arrays via the layout JSON — there was no way to do it through the designer UI.

This PR adds three small improvements:

- Section toolbar button : a draggable "Section" button in the left toolbar; drop it onto any section to create a sub-section
- Binding in property grid : the `binding` field is now editable in the Properties panel when a section is selected, so you can type an array field name directly
- Drag array nodes from Data Source panel : array nodes (those with children) are now draggable; dropping one onto a section creates a sub-section pre-bound to that field
Together these make the full binding workflow possible entirely within the UI, without needing to pre-configure a layout JSON.