### PR TITLE
Fix: show content and footer section if initial layout is empty or binding not set

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -35,16 +35,19 @@ export default class Renderer {
     this.options.element.appendChild(this.headerSection.element);
 
     const contentProperty = this.options.layout.contentSection.binding;
+    const contentData = contentProperty ? this.options.data[contentProperty] : null;
 
-    this.options.data[contentProperty].forEach((data: any) => {
-      const contentSection = new Section(
-        this.options.layout.contentSection,
-        data,
-        [this.options.layout],
-      );
-      this.options.element.appendChild(contentSection.element);
-      this.options.element.appendChild(contentSection.elementSections);
-    });
+    if (Array.isArray(contentData)) {
+      contentData.forEach((data: any) => {
+        const contentSection = new Section(
+          this.options.layout.contentSection,
+          data,
+          [this.options.layout],
+        );
+        this.options.element.appendChild(contentSection.element);
+        this.options.element.appendChild(contentSection.elementSections);
+      });
+    }
 
     this.options.element.appendChild(this.footerSection.element);
   }


### PR DESCRIPTION
# Description:

When the content section's `binding` was empty or didn't match a key in the provided data, `renderer.ts` would throw a TypeError trying to call `.forEach()` on `undefined`. Because the footer was appended after that loop, it would never make it into the DOM leaving both content and footer invisible while header rendered fine.

This PR wraps the content loop in an `Array.isArray()` guard so it only runs when valid data exists, ensuring the footer is always appended regardless.